### PR TITLE
Update FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,2 @@
-custom: https://numfocus.salsalabs.org/donate-to-astropy/index.html
+github: numfocus
+custom: https://numfocus.org/donate-to-astropy


### PR DESCRIPTION
add NumFOCUS github sponsors button (recurring donations only)

This feature is launching today at GitHub Universe!

Also updated custom link to point to the numfocus.org hosted donation page; may help provide added assurance for potential donors re: security/legitimacy.

cc @astrofrog